### PR TITLE
chore: add angular cdk dependency required for material2

### DIFF
--- a/vsts-follower-chrome/package.json
+++ b/vsts-follower-chrome/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^4.0.2",
+    "@angular/cdk": "^2.0.0-beta.8",
     "@angular/common": "^4.0.2",
     "@angular/compiler": "^4.0.2",
     "@angular/compiler-cli": "^4.0.2",
@@ -20,7 +21,6 @@
     "@angular/forms": "^4.0.2",
     "@angular/http": "^4.0.2",
     "@angular/material": "^2.0.0-beta.3",
-    "@angular/cdk": "^2.0.0-beta.8",
     "@angular/platform-browser": "^4.0.2",
     "@angular/platform-browser-dynamic": "^4.0.2",
     "@angular/router": "^4.0.2",

--- a/vsts-follower-chrome/package.json
+++ b/vsts-follower-chrome/package.json
@@ -20,6 +20,7 @@
     "@angular/forms": "^4.0.2",
     "@angular/http": "^4.0.2",
     "@angular/material": "^2.0.0-beta.3",
+    "@angular/cdk": "^2.0.0-beta.8",
     "@angular/platform-browser": "^4.0.2",
     "@angular/platform-browser-dynamic": "^4.0.2",
     "@angular/router": "^4.0.2",


### PR DESCRIPTION
Following https://github.com/angular/material2/blob/master/guides/getting-started.md#step-1-install-angular-material-and-angular-cdk:

> For existing apps, follow these steps to begin using Angular Material.
> 
> Step 1: Install Angular Material and Angular CDK
> 
> npm install --save angular/material angular/cdk
